### PR TITLE
feat: add a second request with a new  prompt

### DIFF
--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -27,7 +27,7 @@ const handler = async (req: Request): Promise<Response> => {
       {
         role: "user",
         content:
-          "create next.js + tailwind css code for button 200 x 100, light purple background, generate text on it. Please create a complete next.js component",
+          "create next.js code with inline styles for a button 200 x 100, light purple background, generate text on it. Please create a complete next.js component",
       },
       {
         role: "assistant",
@@ -35,10 +35,10 @@ const handler = async (req: Request): Promise<Response> => {
                     import React from 'react';
                     const MyComponent = () => {
                       return (
-                        <div className="flex flex-col items-center justify-center h-screen">
-                          <h1 className="text-3xl font-bold mb-4">Hello World</h1>
-                          <p className="text-lg mb-4">Welcome to my Next.js component using Tailwind CSS</p>
-                          <button className="bg-purple-500 text-white px-4 py-2 rounded-lg shadow-md hover:bg-purple-700 focus:outline-none focus:ring-2 focus:ring-purple-600 focus:ring-opacity-50">Click Me</button>
+                        <div style={{ "display": "flex", "flexDirection": "column", "placeItems": "center", "height": "100vh" }}>
+                          <h1 style={{ "fontSize": "1.9rem", "lineHeight": "2.3rem", "fontWeight": "bold", "marginBottom": "1rem" }}>Hello World</h1>
+                          <p style={{ "fontSize": "1.13rem", "lineHeight": "1.8rem", "marginBottom": "1rem" }}>Welcome to my Next.js component using Tailwind CSS</p>
+                          <button style={{ "backgroundColor": "purple", "color": "white", "paddingInline": "1rem", "paddingBlock": "0.5rem" }}>Click Me</button>
                         </div>
                       );
                     };
@@ -51,6 +51,7 @@ const handler = async (req: Request): Promise<Response> => {
           "Please create html code with inline css that creates the following component, Material UI look and feel, return only code",
       },
       { role: "user", content: "DO NOT wrap the returned code with ```" },
+      { role: "user", content: "DO NOT start the returned code with 'html' "},
       ...messages,
     ],
   };

--- a/pages/api/modify.ts
+++ b/pages/api/modify.ts
@@ -1,5 +1,4 @@
 import {
-  ChatGPTMessage,
   OpenAIStream,
   OpenAIStreamPayload,
 } from "../../utils/OpenAIStream";

--- a/pages/api/modify.ts
+++ b/pages/api/modify.ts
@@ -1,0 +1,65 @@
+import {
+  ChatGPTMessage,
+  OpenAIStream,
+  OpenAIStreamPayload,
+} from "../../utils/OpenAIStream";
+
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error("Missing env var from OpenAI");
+}
+
+export const config = {
+  runtime: "edge",
+};
+
+const handler = async (req: Request): Promise<Response> => {
+  const { code } = (await req.json()) as {
+    code: string;
+  };
+
+  if (!code) {
+    return new Response("No code in the request", { status: 400 });
+  }
+
+  const payload: OpenAIStreamPayload = {
+    model: "gpt-3.5-turbo",
+    messages: [
+      {
+        role: "user",
+        content:
+          `Modify the following code:'${code}' so that all of the inline styles are passed as props to the component. Please create a complete next.js component. Please store the props in a variable called 'theme' outside the component`,
+      },
+      {
+        role: "assistant",
+        content: `
+                    import React from 'react';
+
+                    const theme = {
+                        prop1: { "display": "flex", "flexDirection": "column", "placeItems": "center", "height": "100vh" },
+                        prop2: { "fontSize": "1.9rem", "lineHeight": "2.3rem", "fontWeight": "bold", "marginBottom": "1rem" },
+                        prop3: { "fontSize": "1.13rem", "lineHeight": "1.8rem", "marginBottom": "1rem" },
+                        prop4: { "backgroundColor": "purple", "color": "white", "paddingInline": "1rem", "paddingBlock": "0.5rem" }
+                    }
+
+                    const MyComponent = () => {
+                      return (
+                        <div style={theme.prop1}>
+                          <h1 style={theme.prop2}>Hello World</h1>
+                          <p style={theme.prop3}>Welcome to my Next.js component using Tailwind CSS</p>
+                          <button style={theme.prop4}>Click Me</button>
+                        </div>
+                      );
+                    };
+                    export default MyComponent;
+                `,
+      },
+      { role: "user", content: "DO NOT wrap the returned code with ```" },
+      { role: "user", content: "DO NOT start the returned code with 'html' "},
+    ],
+  };
+
+  const stream = await OpenAIStream(payload);
+  return new Response(stream);
+};
+
+export default handler;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,6 +14,7 @@ import Skeleton from "react-loading-skeleton";
 
 const Home: NextPage = () => {
   const [prompt, setPrompt] = useState("");
+  // get the state from useChatGPT function
   const {
     exportedGeneratedCode,
     isLoading,


### PR DESCRIPTION
very basic PR to test the viability of creating a theme picker for the 'generated code'

1) produce code as per main branch
2) create a new api route to modify the generated code
3) pass the modified code to the clipboard

this does not seem to be working as intended, it appears that AI is struggling to extract the inline styles from the JSX and move them into a theme object stored outside the component

https://www.zdnet.com/google-amp/article/how-to-use-chatgpt-to-write-code/

'First, you're going to have to maintain it. ChatGPT is terrible at modifying already-written code. Terrible, as in, it doesn't do it. '